### PR TITLE
chore: update gradle build action to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           distribution: 'zulu'
           java-version: 18
 
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
 
       - name: Test
         run: ./gradlew build
@@ -37,7 +37,7 @@ jobs:
           distribution: 'zulu'
           java-version: 18
 
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v3
 
       - name: Sign and upload artifacts
         run: ./gradlew publish


### PR DESCRIPTION
Out of date Gradle build action updated due to CVE-2023-30853